### PR TITLE
Remove teams access from repository settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -33,14 +33,6 @@ labels:
     description: New feature or change to an existing feature
     color: '#336699'
 
-teams:
-  - name: admins
-    permission: admin
-  - name: ingeno
-    permission: push
-  - name: template-admins
-    permission: admin
-
 branches:
   - name: main
     protection:


### PR DESCRIPTION
These accesses are applied to new repositories that are not using
`probot/settings`, which causes headaches to organization
administrators.

Unfortunately, I was not able to find documentation about this behavior.