### PR TITLE
Fix default assignee for access request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/private-packages-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/private-packages-access-request.yml
@@ -4,7 +4,7 @@ title: '[PAT Request]: '
 labels:
   - access-request
 assignees:
-  - admins
+  - ingeno/admins
 body:
   - type: input
     id: project-name

--- a/.github/ISSUE_TEMPLATE/request_a_pat.md
+++ b/.github/ISSUE_TEMPLATE/request_a_pat.md
@@ -3,7 +3,7 @@ name: Private Package Access Request
 about: Request a Personal Access Token to grant your project access to Ingeno's private packages
 title: "[PAT Request]: "
 labels: "access-request"
-assignees: admins
+assignees: ingeno/admins
 ---
 
 # Request a PAT to access private repository


### PR DESCRIPTION
Tests have shown that not prefixing the team name with the organization
name results in an invalid assignee name. No default assignee was
assigned when creating an issue from this template.

Although only the Markdown version of the template currently works, this
commit fixes the default assignee on the issue form template as well to
avoid discrepancies between the two versions of the same template
concept.